### PR TITLE
fix: receipts root encoding

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -376,7 +376,7 @@ func (b *Backend) ReceiptsRoot(blockRes *tmrpctypes.ResultBlockResults) (common.
 
 		for _, attr := range event.Attributes {
 			if attr.Key == evmtypes.AttributeKeyEthereumReceiptsRoot {
-				return common.Hash([]byte(attr.Value)), nil
+				return common.HexToHash(attr.Value), nil
 			}
 		}
 	}

--- a/x/vm/keeper/keeper.go
+++ b/x/vm/keeper/keeper.go
@@ -162,7 +162,7 @@ func (k Keeper) EmitReceiptsRootEvent(ctx sdk.Context, receiptsRoot common.Hash)
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeReceiptsRoot,
-			sdk.NewAttribute(types.AttributeKeyEthereumReceiptsRoot, string(receiptsRoot.Bytes())),
+			sdk.NewAttribute(types.AttributeKeyEthereumReceiptsRoot, receiptsRoot.Hex()),
 		),
 	)
 }


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

## tl;dr
Currently, `EmitReceiptsRootEvent` emits `receiptsRoot` as `string(receiptsRoot.Bytes())`, which may contain non-UTF-8 characters and result in unreadable or invalid output.
This PR changes the emission to use `receiptsRoot.Hex()` instead, which is UTF-8 safe and human-readable.

## Problem

- `string(receiptsRoot.Bytes())` can include invalid UTF-8 bytes (e.g. 0x00, 0x80–0xFF)
- This leads to:
    - Escaped or malformed data in RPC responses
    - Inconsistent hash reconstruction in clients

## FIx

```go
sdk.NewAttribute(types.AttributeKeyEthereumReceiptsRoot, receiptsRoot.Hex())
```

## Impact

- Safer and cleaner receiptsRoot in events
- No behavioral change — only improves compatibility with RPC consumers

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
